### PR TITLE
Feature/skip bind on empty content

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,7 +56,7 @@ var serverCmd = &cobra.Command{
 			log.Fatal("duo.skey not set in config")
 		}
 
-		log.Debugf("%t %t", viper.Get("server.addr"), version)
+		log.Debugf("%s %s", viper.Get("server.addr"), version)
 
 		srv, err := server.New(serverAddr, version, duoHost, duoIkey, duoSkey)
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -90,10 +90,12 @@ func (s *Server) promptHandler(c echo.Context, factor string) error {
 	curPrompt := s.state[key]
 
 	meta := new(MetadataPayload)
-	err := c.Bind(meta)
-	if err != nil {
-		msg := errors.Wrap(err, "error binding extra metadata object, skipping")
-		logger.Warn(msg)
+	if c.Request().ContentLength != 0 {
+		err := c.Bind(meta)
+		if err != nil {
+			msg := errors.Wrap(err, "error binding extra metadata object, skipping")
+			logger.Warn(msg)
+		}
 	}
 
 	pc, err := newPromptConfig(user, factor, device, passcode, async)


### PR DESCRIPTION
This should resolve #1 . I also tweaked the debug message to use `%s %s` because when trying to run tests on my changes, godel was failing on the type mismatch:

```
❯ ./godelw test
# github.com/palantir/duo-bot/cmd
cmd/server.go:59: Debugf format %t has arg version of wrong type string
FAIL	github.com/palantir/duo-bot/cmd [build failed]
ok  	github.com/palantir/duo-bot/main	0.191s [no tests to run]
ok  	github.com/palantir/duo-bot/server	0.176s [no tests to run]
ok  	github.com/palantir/duo-bot/state	0.098s [no tests to run]
```